### PR TITLE
Use value types to wrap only if a type has at least one method with a value-type receiver

### DIFF
--- a/types/info.go
+++ b/types/info.go
@@ -93,6 +93,7 @@ type RootTypeInfo struct {
 	// The value is the type key for the owning type- this is necessary because
 	// we may assign a method to one type initially but allow another method to steal
 	// it later
+	HasDirectReceiver bool // If true, there is a method with a direct non-pointer receiver
 }
 
 func (r *RootTypeInfo) CanUseMethod(t gotypes.Type, method string) bool {

--- a/types/walker_walk.go
+++ b/types/walker_walk.go
@@ -43,6 +43,11 @@ func (state *TypeWalker) walkSingleType(walkType *TypeInfo) {
 		return
 	}
 
+	// If this is a direct, non-pointered type (root type == type), then that will change how we render the wrapper
+	if walkType.TypeId.TypeKey == walkType.RootType.RootType.TypeKey {
+		walkType.RootType.HasDirectReceiver = true
+	}
+
 	// Loop through each method
 	for _, wrappedMethod := range walkType.MethodToWrap {
 		sig := wrappedMethod.Type().(*gotypes.Signature)


### PR DESCRIPTION
Somewhere I got the brilliant idea that I could simplify my life by using value-type fields for all wrapped values.  Of course this didn't work- lots of stuff breaks if you clone it off (like database/sql.Rows).  So now I'm only using value types as the inner field if there's at least one method with a value-type receiver.  This should hopefully indicate that it is safe to clone a type off.  Having the code handle both pointer and value type inner fields was less complicated than expected, so cheers to me.